### PR TITLE
fix build with google-glog 0.7.0

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-noetic-rosconsole
 	pkgdesc = ROS - ROS console output library.
 	pkgver = 1.14.3
-	pkgrel = 8
+	pkgrel = 9
 	url = https://wiki.ros.org/rosconsole
 	arch = i686
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -4,7 +4,7 @@ url='https://wiki.ros.org/rosconsole'
 pkgname='ros-noetic-rosconsole'
 pkgver='1.14.3'
 arch=('i686' 'x86_64' 'aarch64' 'armv7h' 'armv6h')
-pkgrel=8
+pkgrel=9
 license=('BSD')
 
 ros_makedepends=(
@@ -53,6 +53,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
         -DPYTHON_EXECUTABLE=/usr/bin/python \
         -DSETUPTOOLS_DEB_LAYOUT=OFF \
+        -DCMAKE_CXX_FLAGS="-DGLOG_USE_GLOG_EXPORT" \
         -DROSCONSOLE_BACKEND=glog #log4cxx/glog/print
     make
 }


### PR DESCRIPTION
An extra compile definition is required with the latest `google-glog 0.7.0`: `-DGLOG_USE_GLOG_EXPORT`.

https://github.com/google/glog/blob/ea0748d8df563ec5400648f06e5038b8865b0aa9/src/glog/logging.h#L55